### PR TITLE
Update to newest rules_go release.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,10 +20,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
+    sha256 = "d6b2513456fe2229811da7eb67a444be7785f5323c6708b38d851d2b51e54d83",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.30.0/rules_go-v0.30.0.zip",
     ],
 )
 
@@ -33,7 +33,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@io_bazel_rules_go//:tools_nogo",
-    version = "1.17.1",
+    version = "1.17.6",
 )
 
 http_archive(


### PR DESCRIPTION
See https://github.com/bazelbuild/rules_go/releases/tag/v0.30.0.